### PR TITLE
[firebase_database]added onchildempty to firebase animated list

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.4+1
+
+* Fix crash with pagination with `DocumentReference` (#2044)
+* Minor tweaks to integ tests.
+
 ## 0.13.4
 
 * Support equality comparison on `FieldValue` instances.

--- a/packages/cloud_firestore/cloud_firestore/example/run-tests-web
+++ b/packages/cloud_firestore/cloud_firestore/example/run-tests-web
@@ -1,0 +1,9 @@
+#!/usr/bin/sh
+echo "Moving tests to lib/main.dart..."
+cp test_driver/cloud_firestore.dart lib/main.dart
+
+flutter run -d chrome
+
+echo "Restoring lib/main.dart..."
+git restore lib/main.dart
+

--- a/packages/cloud_firestore/cloud_firestore/lib/src/utils/platform_utils.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/utils/platform_utils.dart
@@ -9,7 +9,10 @@ class _PlatformUtils {
           DocumentSnapshot documentSnapshot) =>
       platform.DocumentSnapshotPlatform(
           documentSnapshot.reference.path,
-          documentSnapshot.data,
+          // We could access `documentSnapshot._delegate.data` directly instead
+          // of going through the getter that `replaceDelegatesWithValuesInMap`
+          // on the data, but this way, the code is not tied to a part-ed lib implementation.
+          _CodecUtility.replaceValueWithDelegatesInMap(documentSnapshot.data),
           platform.SnapshotMetadataPlatform(
             documentSnapshot.metadata.hasPendingWrites,
             documentSnapshot.metadata.isFromCache,

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.4
+version: 0.13.4+1
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+1
+
+* Ensure FieldValueFactoryWeb correctly encodes parameters for arrayRemove/arrayUnion FieldValues.
+
 ## 0.1.1
 
 * Support equality comparison of field values.

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/field_value_factory_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/field_value_factory_web.dart
@@ -7,17 +7,18 @@ import 'package:firebase/firestore.dart' as web;
 import 'package:js/js_util.dart';
 
 import 'package:cloud_firestore_web/src/field_value_web.dart';
+import 'package:cloud_firestore_web/src/utils/codec_utility.dart';
 
 /// An implementation of [FieldValueFactoryPlatform] which builds [FieldValuePlatform]
 /// instance that is [jsify] friendly
 class FieldValueFactoryWeb extends FieldValueFactoryPlatform {
   @override
-  FieldValueWeb arrayRemove(List elements) =>
-      FieldValueWeb(web.FieldValue.arrayRemove(elements));
+  FieldValueWeb arrayRemove(List elements) => FieldValueWeb(
+      web.FieldValue.arrayRemove(CodecUtility.valueEncode(elements)));
 
   @override
-  FieldValueWeb arrayUnion(List elements) =>
-      FieldValueWeb(web.FieldValue.arrayUnion(elements));
+  FieldValueWeb arrayUnion(List elements) => FieldValueWeb(
+      web.FieldValue.arrayUnion(CodecUtility.valueEncode(elements)));
 
   @override
   FieldValueWeb delete() => FieldValueWeb(web.FieldValue.delete());

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_web
 description: The web implementation of cloud_firestore
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
-version: 0.1.1
+version: 0.1.1+1
 
 flutter:
   plugin:

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+2
+
+* Fix Cirrus build by removing WorkspaceSettings.xcsettings file in the iOS example app.
+
 ## 0.1.3+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_crashlytics/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/firebase_crashlytics/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.3+1
+version: 0.1.3+2
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 
 environment:


### PR DESCRIPTION
## Description

I added an option for on child empty on the Firebase animated list

## Related Issues
if the list displays as empty, it simply displays blank, and there seemed to be no easy way to display something else instead

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [x ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ X] I updated CHANGELOG.md to add a description of the change.
- [ X] I signed the [CLA].
- [ X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
